### PR TITLE
docs: fix scoring README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 📚 Documentation
 
 -   [Backend Documentation](backend/README.md)
--   [Backend Scoring Algorithm](backend/SCORING_README.md)
+-   [Backend Scoring Algorithm](backend/documentation/SCORING_README.md)
 -   [Privacy & Compliance Policy](backend/Policy.md)
 -   [Changelog](CHANGELOG.md)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -74,5 +74,5 @@ python -m pytest
 
 For detailed documentation, see:
 
--   [SCORING_README.md](SCORING_README.md) - Scoring algorithm details
+-   [SCORING_README.md](documentation/SCORING_README.md) - Scoring algorithm details
 -   [Policy.md](Policy.md) - Data retention and privacy policies


### PR DESCRIPTION
## Summary
- update scoring README link paths in README docs

## Testing
- `npm test` *(fails: TELEGRAM_BOT_TOKEN environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_684001e3c6f0832299e1755ac9b6c109